### PR TITLE
typo in config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,7 @@ META:
     annotation_file:
     reference_folder:
 FILTER:
-    IllumiaClip: 
+    IlluminaClip: 
     5PrimeSmartAdapter:
     Cell_barcode:
         start:


### PR DESCRIPTION
- Discovered a typo in config.yaml which I uses as templated giving my errors.

-  similar thing happend to me using code from the wiki. The wiki can't be changed as a pull request, so I'll just mention it: 
https://github.com/Hoohm/dropSeqPipe/wiki/Create-config-files#2-samplescsv---samples-parameters
`read_lengths` needs to be `read_length`
Note, the sample.csv is correct (read_length) but it might be worth pointing out that this line has to be kept in the csv as it is.

- Also `semi-colon` should be just `colon` in this section:
https://github.com/Hoohm/dropSeqPipe/wiki/Create-config-files#1-configyaml---executables-system-and-experiment-parameters

Really like version 0.3, I'm trying it out at the moment and will probably get back with feedback soon. Thanks
