### PR TITLE
Creating "violine", "count vs gene" and "count vs UMI" plots plus export seurat objects

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -94,6 +94,14 @@ rule map:
         expand('logs/{sample}_hist_out_cell.txt', sample=samples.index),
         expand('plots/{sample}_knee_plot.pdf', sample=samples.index),
         'reports/star.html',
+        'plots/violinplots_comparison_UMI.pdf',
+        'plots/UMI_vs_counts.html',
+        # 'plots/UMI_vs_counts.pdf',
+        'plots/UMI_vs_gene.html',
+        # 'plots/UMI_vs_gene.pdf',
+        'plots/Count_vs_gene.html',
+        # 'plots/Count_vs_gene.pdf',
+        'summary/R_Seurat_objects.rdata',
         'plots/yield.pdf'
         
 rule extract:

--- a/Snakefile
+++ b/Snakefile
@@ -95,12 +95,12 @@ rule map:
         expand('plots/{sample}_knee_plot.pdf', sample=samples.index),
         'reports/star.html',
         'plots/violinplots_comparison_UMI.pdf',
-        'plots/UMI_vs_counts.html',
-        # 'plots/UMI_vs_counts.pdf',
-        'plots/UMI_vs_gene.html',
-        # 'plots/UMI_vs_gene.pdf',
-        'plots/Count_vs_gene.html',
-        # 'plots/Count_vs_gene.pdf',
+        # 'plots/UMI_vs_counts.html',
+        'plots/UMI_vs_counts.pdf',
+        # 'plots/UMI_vs_gene.html',
+        'plots/UMI_vs_gene.pdf',
+        # 'plots/Count_vs_gene.html',
+        'plots/Count_vs_gene.pdf',
         'summary/R_Seurat_objects.rdata',
         'plots/yield.pdf'
         

--- a/envs/plots_ext.yaml
+++ b/envs/plots_ext.yaml
@@ -1,0 +1,17 @@
+channels:
+  - conda-forge
+dependencies:
+  - r=3.4.1
+  - r-ggplot2
+  - r-ggpubr
+  - r-gridextra
+  - r-reshape2
+  - r-viridis
+  - r-stringdist
+  - r-dplyr
+  - r-mvtnorm
+  - r-seurat
+  - r-hmisc
+  - r-tidyverse
+  - r-devtools
+  - r-rcolorbrewer

--- a/envs/plots_ext.yaml
+++ b/envs/plots_ext.yaml
@@ -15,3 +15,5 @@ dependencies:
   - r-tidyverse
   - r-devtools
   - r-rcolorbrewer
+  - r-rcpp=0.12.14
+  - libgfortran

--- a/envs/plots_ext.yaml
+++ b/envs/plots_ext.yaml
@@ -1,14 +1,16 @@
 channels:
   - conda-forge
+  - bioconda
+  - r
 dependencies:
   - r=3.4.1
-  - r-ggplot2
+  - r-ggplot2=2.2.1
   - r-ggpubr
   - r-gridextra
   - r-reshape2
   - r-viridis
   - r-stringdist
-  - r-dplyr
+  - r-dplyr=0.7.4
   - r-mvtnorm
   - r-seurat
   - r-hmisc

--- a/rules/map.smk
+++ b/rules/map.smk
@@ -199,12 +199,12 @@ rule violine_plots:
 	conda: '../envs/plots_ext.yaml'
 	output:
 		pdf_violine='plots/violinplots_comparison_UMI.pdf',
-		html_umivscounts='plots/UMI_vs_counts.html',
-#		pdf_umivscounts='plots/UMI_vs_counts.pdf',
-		html_umi_vs_gene='plots/UMI_vs_gene.html',
-#		pdf_umi_vs_gene='plots/UMI_vs_gene.pdf',
-		html_count_vs_gene='plots/Count_vs_gene.html',
-#		pdf_count_vs_gene='plots/Count_vs_gene.pdf',
+#		html_umivscounts='plots/UMI_vs_counts.html',
+		pdf_umivscounts='plots/UMI_vs_counts.pdf',
+#		html_umi_vs_gene='plots/UMI_vs_gene.html',
+		pdf_umi_vs_gene='plots/UMI_vs_gene.pdf',
+#		html_count_vs_gene='plots/Count_vs_gene.html',
+		pdf_count_vs_gene='plots/Count_vs_gene.pdf',
 		R_objects='summary/R_Seurat_objects.rdata'
 	script:
 		'../scripts/plot_violine.R'

--- a/rules/map.smk
+++ b/rules/map.smk
@@ -29,7 +29,7 @@ rule STAR_align:
 				config['MAPPING']['STAR']['outFilterMatchNmin'],
 				config['MAPPING']['STAR']['outFilterMatchNminOverLread'],
 				config['MAPPING']['STAR']['outFilterScoreMinOverLread'],),
-		index=lambda wildcards: star_index_prefix + '_' + str(samples.loc[wildcards.sample,'read_length']) + '/'	
+		index=lambda wildcards: star_index_prefix + '_' + str(samples.loc[wildcards.sample,'read_length']) + '/'
 	threads: 24
 	wrapper:
 		"0.22.0/bio/star/align"
@@ -167,7 +167,7 @@ rule plot_yield:
 rule plot_knee_plot:
 	input:
 		'logs/{sample}_hist_out_cell.txt'
-	params: 
+	params:
 		cells=lambda wildcards: samples.loc[wildcards.sample,'expected_cells'],
 		edit_distance=config['EXTRACTION']['UMI-edit-distance']
 	conda: '../envs/plots.yaml'
@@ -180,10 +180,31 @@ rule plot_knee_plot_whitelist:
 	input:
 		data='logs/{sample}_hist_out_cell.txt',
 		barcodes='barcodes.csv'
-	params: 
+	params:
 		cells=lambda wildcards: samples.loc[wildcards.sample,'expected_cells']
 	conda: '../envs/plots.yaml'
 	output:
 		pdf='plots/{sample}_knee_plot.pdf'
 	script:
 		'../scripts/plot_knee_plot.R'
+
+rule violine_plots:
+	input:
+		UMIs='summary/umi_expression_matrix.tsv',
+		counts='summary/counts_expression_matrix.tsv',
+		design='samples.csv'
+#	params:
+#		cells=lambda wildcards: samples.loc[wildcards.sample,'expected_cells'],
+#		edit_distance=config['EXTRACTION']['UMI-edit-distance']
+	conda: '../envs/plots_ext.yaml'
+	output:
+		pdf_violine='plots/violinplots_comparison_UMI.pdf',
+		html_umivscounts='plots/UMI_vs_counts.html',
+#		pdf_umivscounts='plots/UMI_vs_counts.pdf',
+		html_umi_vs_gene='plots/UMI_vs_gene.html',
+#		pdf_umi_vs_gene='plots/UMI_vs_gene.pdf',
+		html_count_vs_gene='plots/Count_vs_gene.html',
+#		pdf_count_vs_gene='plots/Count_vs_gene.pdf',
+		R_objects='summary/R_Seurat_objects.rdata'
+	script:
+		'../scripts/plot_violine.R'

--- a/scripts/plot_violine.R
+++ b/scripts/plot_violine.R
@@ -148,7 +148,7 @@ gg <- ggplot(meta.data, aes(x = nUMI, y = nGene, color=orig.ident)) +
 # htmlwidgets::saveWidget(ggplotly(gg),
                         # file.path(getwd(), snakemake@output$html_umi_vs_gene))
 ggsave(gg, file = file.path(getwd(), snakemake@output$pdf_umi_vs_gene),
-#        width = 12, height = 7)
+       width = 12, height = 7)
 
 
 

--- a/scripts/plot_violine.R
+++ b/scripts/plot_violine.R
@@ -15,8 +15,6 @@ library(dplyr) # Dataframe manipulation
 library(Matrix) # Sparse matrices
 library(stringr)
 library(RColorBrewer)
-#library(matrixStats)
-# library(Hmisc) # for cut2 function
 library(devtools)
 library(Seurat)
 library(plotly)
@@ -28,7 +26,6 @@ library(plotly)
 #         ...
 
 # importing UMI
-# umi_matrix             <- read.csv(file.path(path,'summary/umi_expression_matrix.tsv'), sep='\t', header = TRUE, row.names = 1, check.names = FALSE) %>%
 # importing counts ( summary/counts_expression_matrix.tsv )
 count_matrix <- read.csv(snakemake@input$counts, sep = "\t",
                          header = TRUE, row.names = 1,
@@ -103,24 +100,18 @@ gg <- ggplot(meta.data, aes(x = nUMI, y=nCounts, color=orig.ident)) +
      x = "Number of UMIs per Bead [k]",
      y = "Number of Counts per Bead [k]")
 
-htmlwidgets::saveWidget(ggplotly(gg), file.path(getwd(),snakemake@output$html_umivscounts))
-# ggsave(gg, file = file.path(getwd(), snakemake@output$pdf_umivscounts), width=12,height=7)
+  # dev.new()
+# htmlwidgets::saveWidget(ggplotly(gg), file.path(getwd(),snakemake@output$html_umivscounts))
+ ggsave(gg, file = file.path(getwd(), snakemake@output$pdf_umivscounts), width=12,height=7)
 
 # how about unaligned reads/UMI?
 # Note(Seb): raw.data is actually filtered data i.e. nr of genes likely to be smaller than input data!
 mito.gene.names  <- grep("^mt-", rownames(seuratobj@raw.data), value=TRUE)
-# mito.gene.names2  <- subset(mito.gene.names, mito.gene.names %in% rownames(seuratobj@raw.data))
 sribo.gene.names <- grep("^Rps", rownames(seuratobj@raw.data), value=TRUE)
 lribo.gene.names <- grep("^Rpl", rownames(seuratobj@raw.data), value=TRUE)
 
 col.total            <- Matrix::colSums(seuratobj@raw.data)
-# col.total.count          <- Matrix::colSums(mycount@raw.data)
 meta.data$col.total   <- col.total
-# meta.data$col.total.count <- col.total.count
-# mito.percent.counts <- mito.percent.counts
-# sribo.pct <- sribo.pct
-# lribo.pct <- lribo.pct
-# ribo_tot <- ribo_tot
 
 seuratobj.top_50   <- apply(seuratobj@raw.data, 2, function(x) sum(x[order(x, decreasing = TRUE)][1:50])/sum(x))
 # mycount.top_50 <- apply(mycount@raw.data, 2, function(x) sum(x[order(x, decreasing = TRUE)][1:50])/sum(x))
@@ -133,17 +124,6 @@ seuratobj <- AddMetaData(seuratobj, seuratobj.top_50, "top50")
 tmp <- seuratobj@meta.data$nUMI/seuratobj@meta.data$nGene
 names(tmp) <- rownames(seuratobj@meta.data)
 seuratobj <- AddMetaData(seuratobj, tmp, "umi.per.gene")
-
-# # tmp=(seuratobj@meta.data[,"nUMI",drop=F]/seuratobj@meta.data$nGene)
-# mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[sribo.gene.names, ])/col.total.count, "pct.sribo")
-# mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[lribo.gene.names, ])/col.total.count, "pct.lribo")
-# mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[unique(c(sribo.gene.names, lribo.gene.names)), ])/col.total.count, "pct.Ribo")
-# mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[mito.gene.names, ])/col.total.count, "pct.mito")
-# mycount <- AddMetaData(mycount, mycount.top_50, "top50")
-# tmp <- mycount@meta.data$nUMI/mycount@meta.data$nGene
-# names(tmp) <- rownames(mycount@meta.data)
-# mycount <- AddMetaData(mycount, tmp, "umi.per.gene")
-# # mycount@meta.data$count.per.gene <- mycount@meta.data$nUMI/mycount@meta.data$nGene
 
 
 gg <- VlnPlot(seuratobj,
@@ -164,9 +144,10 @@ gg <- ggplot(meta.data, aes(x = nUMI, y = nGene, color=orig.ident)) +
        x = "Number of UMIs per Bead [k]",
        y = "Number of Genes per Bead [k]")
 
-htmlwidgets::saveWidget(ggplotly(gg),
-                        file.path(getwd(), snakemake@output$html_umi_vs_gene))
-# ggsave(gg, file = file.path(getwd(), snakemake@output$pdf_umi_vs_gene),
+  # dev.new()
+# htmlwidgets::saveWidget(ggplotly(gg),
+                        # file.path(getwd(), snakemake@output$html_umi_vs_gene))
+ggsave(gg, file = file.path(getwd(), snakemake@output$pdf_umi_vs_gene),
 #        width = 12, height = 7)
 
 
@@ -179,11 +160,12 @@ gg <- ggplot(meta.data, aes(x = nCounts, y = nGene, color=orig.ident)) +
        x = "Number of Counts per Bead [k]",
        y = "Number of Genes per Bead [k]")
 
-htmlwidgets::saveWidget(ggplotly(gg),
-                        file.path(getwd(), snakemake@output$html_count_vs_gene))
+  # dev.new()
+# htmlwidgets::saveWidget(ggplotly(gg),
+  #                       file.path(getwd(), snakemake@output$html_count_vs_gene))
 
-# ggsave(gg, file = file.path(getwd(), snakemake@output$pdf_count_vs_gene),
-#        width = 12, height = 7)
+ggsave(gg, file = file.path(getwd(), snakemake@output$pdf_count_vs_gene),
+        width = 12, height = 7)
 
 
 # head(meta.data,2)

--- a/scripts/plot_violine.R
+++ b/scripts/plot_violine.R
@@ -1,0 +1,186 @@
+#' ---
+#' title:  plot_violine.R
+#' author: Sebastian Mueller (sebm_at_posteo.de)
+#' date:   2018-04-10
+#' ---
+### for debug
+# If you wish to access the snakefile object first invoke snakemake and save the session automatically
+# Since there are no debug flags to my knowledge, just uncomment the line below and run snakemake which
+# creates an R object that can be loaded into a custom R session
+# save.image(file="R_workspace_debug.rdata")
+# load("R_workspace_debug.rdata")
+####/debug
+library(plyr)
+library(dplyr) # Dataframe manipulation
+library(Matrix) # Sparse matrices
+library(stringr)
+library(RColorBrewer)
+#library(matrixStats)
+# library(Hmisc) # for cut2 function
+library(devtools)
+library(Seurat)
+library(plotly)
+
+# rule map in Snakefile
+# rule map:
+#     input:
+#         'plots/violinplots_comparison_UMI.pdf',
+#         ...
+
+# importing UMI
+# umi_matrix             <- read.csv(file.path(path,'summary/umi_expression_matrix.tsv'), sep='\t', header = TRUE, row.names = 1, check.names = FALSE) %>%
+# importing counts ( summary/counts_expression_matrix.tsv )
+count_matrix <- read.csv(snakemake@input$counts, sep = "\t",
+                         header = TRUE, row.names = 1,
+                         check.names = FALSE)
+# importing UMIs ( summary/umi_expression_matrix.tsv )
+umi_matrix   <- read.csv(snakemake@input$UMIs,
+                         sep = "\t",
+                         header = TRUE,
+                         row.names = 1,
+                         check.names = FALSE)
+design       <- read.csv(snakemake@input$design, stringsAsFactors = TRUE,
+                         header = TRUE,
+                         row.names = NULL)
+
+metaData <- data.frame(cellNames = colnames(umi_matrix)) %>%
+  mutate(samples = factor(str_replace(cellNames,"_[^_]*$",""))) %>%
+  mutate(barcode = factor(str_replace(cellNames,".+_",""))) %>%
+  left_join(design, by = "samples")
+rownames(metaData) <- metaData$cellNames
+
+# possible to set is.expr = -1 to avoid filtering whilst creating
+# myumi <- CreateSeuratObject(raw.data = umi_matrix, meta.data = metaData, is.expr = -1)
+myumi <- CreateSeuratObject(raw.data = umi_matrix, meta.data = metaData)
+myumi <- SetAllIdent(object = myumi, id = "samples")
+# relabel cell idenity (https://github.com/satijalab/seurat/issues/380)
+myumi@meta.data$orig.ident <- myumi@meta.data$samples
+
+mycount <- CreateSeuratObject(raw.data = count_matrix, meta.data = metaData)
+mycount <- SetAllIdent(object = mycount, id = "samples")
+mycount@meta.data$orig.ident <- mycount@meta.data$samples
+# turn off filtering
+
+# note, the @meta.data slot contains usefull summary stuff
+# head(mycount@meta.data,2)
+#                              nGene nUMI expected_cells read_length      barcode
+# dropseqLib1_ACTAACATTATT    15   33            400         100 ACTAACATTATT
+# dropseqLib1_GAGTCTGAGGCG     5    9            400         100 GAGTCTGAGGCG
+#                                       origin      origin
+# dropseqLib1_ACTAACATTATT dropseqLib1 dropseqLib1
+# dropseqLib1_GAGTCTGAGGCG dropseqLib1 dropseqLib1
+meta.data         <- myumi@meta.data
+meta.data$nCounts <- mycount@meta.data$nUMI
+
+
+# mytheme <- theme_bw(base_size = 9) +
+mytheme <- theme_bw() +
+  theme(legend.position = "right",
+        axis.ticks = element_blank(),
+        axis.text.x = element_text(angle = 300, hjust = 0))
+theme_set(mytheme)
+
+# predefined ggplot layers for subsequent plots
+gglayers <- list(
+  geom_smooth(),
+  geom_point(size = .5),
+  scale_y_continuous(labels = scales::unit_format(unit = "", scale = 1e-3, digits = 2),
+                     breaks = scales::pretty_breaks(n = 8)),
+  scale_x_continuous(labels = scales::unit_format(unit = "", scale = 1e-3, digits = 2),
+                     breaks = scales::pretty_breaks(n = 8))
+)
+
+gg <- ggplot(meta.data, aes(x = nUMI, y=nCounts, color=orig.ident)) +
+  #   coord_trans(y="log10",x = "log10") +
+  gglayers +
+  geom_abline(intercept = 0, slope = 1) +
+  labs(title = "UMI counts vs raw Counts",
+     subtitle = "Number of UMIs and raw Counts for each Bead",
+     x = "Number of UMIs per Bead [k]",
+     y = "Number of Counts per Bead [k]")
+
+htmlwidgets::saveWidget(ggplotly(gg), file.path(getwd(),snakemake@output$html_umivscounts))
+ggsave(gg, file = file.path(getwd(), snakemake@output$pdf_umivscounts), width=12,height=7)
+
+# how about unaligned reads/UMI?
+# Note(Seb): raw.data is actually filtered data i.e. nr of genes likely to be smaller than input data!
+mito.gene.names  <- grep("^mt-", rownames(myumi@raw.data), value=TRUE)
+# mito.gene.names2  <- subset(mito.gene.names, mito.gene.names %in% rownames(myumi@raw.data))
+sribo.gene.names <- grep("^Rps", rownames(myumi@raw.data), value=TRUE)
+lribo.gene.names <- grep("^Rpl", rownames(myumi@raw.data), value=TRUE)
+
+col.total.umi            <- Matrix::colSums(myumi@raw.data)
+col.total.count          <- Matrix::colSums(mycount@raw.data)
+meta.data$col.total.umi   <- col.total.umi
+meta.data$col.total.count <- col.total.count
+# mito.percent.counts <- mito.percent.counts
+# sribo.pct <- sribo.pct
+# lribo.pct <- lribo.pct
+# ribo_tot <- ribo_tot
+
+myumi.top_50   <- apply(myumi@raw.data, 2, function(x) sum(x[order(x, decreasing = TRUE)][1:50])/sum(x))
+mycount.top_50 <- apply(mycount@raw.data, 2, function(x) sum(x[order(x, decreasing = TRUE)][1:50])/sum(x))
+
+myumi <- AddMetaData(myumi, Matrix::colSums(myumi@raw.data[sribo.gene.names, ])/col.total.umi, "pct.sribo")
+myumi <- AddMetaData(myumi, Matrix::colSums(myumi@raw.data[lribo.gene.names, ])/col.total.umi, "pct.lribo")
+myumi <- AddMetaData(myumi, Matrix::colSums(myumi@raw.data[unique(c(sribo.gene.names, lribo.gene.names)), ])/col.total.umi, "pct.Ribo")
+myumi <- AddMetaData(myumi, Matrix::colSums(myumi@raw.data[mito.gene.names, ])/col.total.umi, "pct.mito")
+myumi <- AddMetaData(myumi, myumi.top_50, "top50")
+tmp <- myumi@meta.data$nUMI/myumi@meta.data$nGene
+names(tmp) <- rownames(myumi@meta.data)
+myumi <- AddMetaData(myumi, tmp, "umi.per.gene")
+
+# tmp=(myumi@meta.data[,"nUMI",drop=F]/myumi@meta.data$nGene)
+mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[sribo.gene.names, ])/col.total.count, "pct.sribo")
+mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[lribo.gene.names, ])/col.total.count, "pct.lribo")
+mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[unique(c(sribo.gene.names, lribo.gene.names)), ])/col.total.count, "pct.Ribo")
+mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[mito.gene.names, ])/col.total.count, "pct.mito")
+mycount <- AddMetaData(mycount, mycount.top_50, "top50")
+tmp <- mycount@meta.data$nUMI/mycount@meta.data$nGene
+names(tmp) <- rownames(mycount@meta.data)
+mycount <- AddMetaData(mycount, tmp, "umi.per.gene")
+# mycount@meta.data$count.per.gene <- mycount@meta.data$nUMI/mycount@meta.data$nGene
+
+
+gg <- VlnPlot(myumi,
+              c("nUMI", "nGene", "top50", "umi.per.gene", "pct.Ribo", "pct.mito"),
+              x.lab.rot = TRUE, do.return = TRUE)
+# ggsave(gg,file=file.path("violinplots_comparison_UMI.pdf"),width=18,height=18)
+ggsave(gg, file  = snakemake@output$pdf_violine, width = 18, height = 18)
+# gg <- VlnPlot(mycount,c("nUMI", "nGene", "top50", "count.per.gene","pct.Ribo", "pct.mito"), x.lab.rot = TRUE, do.return = TRUE)
+# ggsave(gg,file=file.path("violinplots_comparison_count.pdf"),width=18,height=18)
+
+# gg <- GenePlot(object = myumi, gene1 = "nUMI", gene2 = "nGene")
+# ggsave(gg,file=file.path("violinplots_comparison.pdf"),width=18,height=18)
+
+
+gg <- ggplot(myumi@meta.data, aes(x = nUMI, y = nGene, color=orig.ident)) +
+  gglayers +
+  labs(title = "Genes (pooled mouse and human set) vs UMIs for each bead",
+       x = "Number of UMIs per Bead [k]",
+       y = "Number of Genes per Bead [k]")
+
+htmlwidgets::saveWidget(ggplotly(gg),
+                        file.path(getwd(), snakemake@output$html_umi_vs_gene))
+# ggsave(gg, file = file.path(getwd(), snakemake@output$pdf_umi_vs_gene),
+#        width = 12, height = 7)
+
+
+
+################################################################################
+## same for Counts instead UMIs (using mycount object)
+gg <- ggplot(mycount@meta.data, aes(x = nUMI, y = nGene, color=orig.ident)) +
+  gglayers +
+  labs(title = "Genes (pooled mouse and human set) vs Counts for each bead",
+       x = "Number of Counts per Bead [k]",
+       y = "Number of Genes per Bead [k]")
+
+htmlwidgets::saveWidget(ggplotly(gg),
+                        file.path(getwd(), snakemake@output$html_count_vs_gene))
+
+# ggsave(gg, file = file.path(getwd(), snakemake@output$pdf_count_vs_gene),
+#        width = 12, height = 7)
+
+
+save(snakemake, myumi, mycount,
+     file=file.path(getwd(), snakemake@output$R_objects))

--- a/scripts/plot_violine.R
+++ b/scripts/plot_violine.R
@@ -70,7 +70,11 @@ mycount@meta.data$orig.ident <- mycount@meta.data$samples
 # dropseqLib1_ACTAACATTATT dropseqLib1 dropseqLib1
 # dropseqLib1_GAGTCTGAGGCG dropseqLib1 dropseqLib1
 meta.data         <- seuratobj@meta.data
+# combining UMIs and Counts in to one Seurat object
 meta.data$nCounts <- mycount@meta.data$nUMI
+seuratobj@meta.data         <- meta.data
+# delete since Counts have been added to seuratobj as nCounts column
+rm(mycount)
 
 
 # mytheme <- theme_bw(base_size = 9) +
@@ -109,37 +113,37 @@ mito.gene.names  <- grep("^mt-", rownames(seuratobj@raw.data), value=TRUE)
 sribo.gene.names <- grep("^Rps", rownames(seuratobj@raw.data), value=TRUE)
 lribo.gene.names <- grep("^Rpl", rownames(seuratobj@raw.data), value=TRUE)
 
-col.total.umi            <- Matrix::colSums(seuratobj@raw.data)
-col.total.count          <- Matrix::colSums(mycount@raw.data)
-meta.data$col.total.umi   <- col.total.umi
-meta.data$col.total.count <- col.total.count
+col.total            <- Matrix::colSums(seuratobj@raw.data)
+# col.total.count          <- Matrix::colSums(mycount@raw.data)
+meta.data$col.total   <- col.total
+# meta.data$col.total.count <- col.total.count
 # mito.percent.counts <- mito.percent.counts
 # sribo.pct <- sribo.pct
 # lribo.pct <- lribo.pct
 # ribo_tot <- ribo_tot
 
 seuratobj.top_50   <- apply(seuratobj@raw.data, 2, function(x) sum(x[order(x, decreasing = TRUE)][1:50])/sum(x))
-mycount.top_50 <- apply(mycount@raw.data, 2, function(x) sum(x[order(x, decreasing = TRUE)][1:50])/sum(x))
+# mycount.top_50 <- apply(mycount@raw.data, 2, function(x) sum(x[order(x, decreasing = TRUE)][1:50])/sum(x))
 
-seuratobj <- AddMetaData(seuratobj, Matrix::colSums(seuratobj@raw.data[sribo.gene.names, ])/col.total.umi, "pct.sribo")
-seuratobj <- AddMetaData(seuratobj, Matrix::colSums(seuratobj@raw.data[lribo.gene.names, ])/col.total.umi, "pct.lribo")
-seuratobj <- AddMetaData(seuratobj, Matrix::colSums(seuratobj@raw.data[unique(c(sribo.gene.names, lribo.gene.names)), ])/col.total.umi, "pct.Ribo")
-seuratobj <- AddMetaData(seuratobj, Matrix::colSums(seuratobj@raw.data[mito.gene.names, ])/col.total.umi, "pct.mito")
+seuratobj <- AddMetaData(seuratobj, Matrix::colSums(seuratobj@raw.data[sribo.gene.names, ])/col.total, "pct.sribo")
+seuratobj <- AddMetaData(seuratobj, Matrix::colSums(seuratobj@raw.data[lribo.gene.names, ])/col.total, "pct.lribo")
+seuratobj <- AddMetaData(seuratobj, Matrix::colSums(seuratobj@raw.data[unique(c(sribo.gene.names, lribo.gene.names)), ])/col.total, "pct.Ribo")
+seuratobj <- AddMetaData(seuratobj, Matrix::colSums(seuratobj@raw.data[mito.gene.names, ])/col.total, "pct.mito")
 seuratobj <- AddMetaData(seuratobj, seuratobj.top_50, "top50")
 tmp <- seuratobj@meta.data$nUMI/seuratobj@meta.data$nGene
 names(tmp) <- rownames(seuratobj@meta.data)
 seuratobj <- AddMetaData(seuratobj, tmp, "umi.per.gene")
 
-# tmp=(seuratobj@meta.data[,"nUMI",drop=F]/seuratobj@meta.data$nGene)
-mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[sribo.gene.names, ])/col.total.count, "pct.sribo")
-mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[lribo.gene.names, ])/col.total.count, "pct.lribo")
-mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[unique(c(sribo.gene.names, lribo.gene.names)), ])/col.total.count, "pct.Ribo")
-mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[mito.gene.names, ])/col.total.count, "pct.mito")
-mycount <- AddMetaData(mycount, mycount.top_50, "top50")
-tmp <- mycount@meta.data$nUMI/mycount@meta.data$nGene
-names(tmp) <- rownames(mycount@meta.data)
-mycount <- AddMetaData(mycount, tmp, "umi.per.gene")
-# mycount@meta.data$count.per.gene <- mycount@meta.data$nUMI/mycount@meta.data$nGene
+# # tmp=(seuratobj@meta.data[,"nUMI",drop=F]/seuratobj@meta.data$nGene)
+# mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[sribo.gene.names, ])/col.total.count, "pct.sribo")
+# mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[lribo.gene.names, ])/col.total.count, "pct.lribo")
+# mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[unique(c(sribo.gene.names, lribo.gene.names)), ])/col.total.count, "pct.Ribo")
+# mycount <- AddMetaData(mycount, Matrix::colSums(mycount@raw.data[mito.gene.names, ])/col.total.count, "pct.mito")
+# mycount <- AddMetaData(mycount, mycount.top_50, "top50")
+# tmp <- mycount@meta.data$nUMI/mycount@meta.data$nGene
+# names(tmp) <- rownames(mycount@meta.data)
+# mycount <- AddMetaData(mycount, tmp, "umi.per.gene")
+# # mycount@meta.data$count.per.gene <- mycount@meta.data$nUMI/mycount@meta.data$nGene
 
 
 gg <- VlnPlot(seuratobj,
@@ -154,7 +158,7 @@ ggsave(gg, file  = snakemake@output$pdf_violine, width = 18, height = 18)
 # ggsave(gg,file=file.path("violinplots_comparison.pdf"),width=18,height=18)
 
 
-gg <- ggplot(seuratobj@meta.data, aes(x = nUMI, y = nGene, color=orig.ident)) +
+gg <- ggplot(meta.data, aes(x = nUMI, y = nGene, color=orig.ident)) +
   gglayers +
   labs(title = "Genes (pooled mouse and human set) vs UMIs for each bead",
        x = "Number of UMIs per Bead [k]",
@@ -169,7 +173,7 @@ htmlwidgets::saveWidget(ggplotly(gg),
 
 ################################################################################
 ## same for Counts instead UMIs (using mycount object)
-gg <- ggplot(mycount@meta.data, aes(x = nUMI, y = nGene, color=orig.ident)) +
+gg <- ggplot(meta.data, aes(x = nCounts, y = nGene, color=orig.ident)) +
   gglayers +
   labs(title = "Genes (pooled mouse and human set) vs Counts for each bead",
        x = "Number of Counts per Bead [k]",
@@ -182,7 +186,7 @@ htmlwidgets::saveWidget(ggplotly(gg),
 #        width = 12, height = 7)
 
 
-# head(seuratobj@meta.data,2)
+# head(meta.data,2)
 #                              nGene nUMI                    cellNames         samples      barcode expected_cells read_length  batch      orig.ident pct.sribo  pct.lribo  pct.Ribo  pct.mito     top50 umi.per.gene
 # sample1_GAGTCTGAGGCG     6    6 sample1_GAGTCTGAGGCG sample1 GAGTCTGAGGCG            100         100 batch1 sample1 0.0000000 0.00000000 0.0000000 0.0000000 1.0000000     1.000000
 # sample1_CAGCCCTCAGTA   264  437 sample1_CAGCCCTCAGTA sample1 CAGCCCTCAGTA            100         100 batch1 sample1 0.0389016 0.07551487 0.1144165 0.0228833 0.5102975     1.655303


### PR DESCRIPTION
Hi Patrick,

I've updated code from another branch (seb_plots) into a new branch on my fork (seurat_violine_etc) in order to make a pull request. Not sure on how to go from here since you might not want to merge it into master (it didn't work to ask for another branch to merge into)?

This PR adds a few more diagnostics plots to assess mitochandrial/ribosomal etc fractions (see below).

It seems to run for my data, but was curious if you like it and works for you?
As for earlier versions (seb_plots branch(, I've taken out a few plots to clean it up.
It basically adds 3 plots as demonstrated below on the [Macosko data](https://trace.ncbi.nlm.nih.gov/Traces/sra/sra.cgi?study=SRP049775)  

- Violine plots based on internal Seurat functions:

![violinplots_comparison_umi](https://user-images.githubusercontent.com/20091739/42419587-018df5a4-82b0-11e8-859e-15655b0c2d2d.png)

- UMI vs Counts:
![umi_vs_counts](https://user-images.githubusercontent.com/20091739/42419573-cd1c8100-82af-11e8-935b-750edd57e865.png)

- Counts vs Genes:
![count_vs_gene](https://user-images.githubusercontent.com/20091739/42419571-bcfb99d2-82af-11e8-9172-dbc801060abf.png)

If it is too experimental, it is also conceivable to add another rule (so one can choose to not run it)