### PR TITLE
adding cutadapt rule in test data config to get it runable

### DIFF
--- a/.test/config.yaml
+++ b/.test/config.yaml
@@ -34,11 +34,23 @@ FILTER:
             seedMismatches: 2
             palindromeClipThreshold: 30
             simpleClipThreshold: 10
+    cutadapt:
+        adapters-file: NexteraPE-PE.fa
+        R1:
+            quality-filter: 20
+            maximum-Ns: 0
+            extra-params: ''
+        R2:
+            quality-filter: 20
+            minimum-adapters-overlap: 6
+            minimum-length: 15
+            extra-params: ''
 EXTRACTION:
     UMI-edit-distance: 1
     minimum-counts-per-UMI: 0
 MAPPING:
     STAR:
+        genomeChrBinNbits: 18
         outFilterMismatchNmax: 10
         outFilterMismatchNoverLmax: 0.3
         outFilterMismatchNoverReadLmax: 1


### PR DESCRIPTION
This is a small amendment towards getting the .test data running requiring cut adapt rules.

Note, lanes pooling doesn't work at this time, I couldn't figure out how the data has to be named (sample_L00*_R1_001.fastq.gz or sample_R1_001.fastq.gz or even different). It seems to be incompatible with `rule_fastqc` and/or others, could you fix that as well? Thanks!