### PR TITLE
Fix plot rna metrics.r & extract_expression_single.smk

### DIFF
--- a/rules/extract_expression_single.smk
+++ b/rules/extract_expression_single.smk
@@ -191,7 +191,7 @@ rule plot_umi_per_gene:
 
 rule plot_rna_metrics:
 	input:
-		'logs/{sample}_rna_metrics.txt'
+		rna_metrics='logs/{sample}_rna_metrics.txt'
 	params: 
 		cells=lambda wildcards: int(samples.loc[wildcards.sample,'expected_cells'])
 	conda: '../envs/plots.yaml'

--- a/scripts/plot_rna_metrics.R
+++ b/scripts/plot_rna_metrics.R
@@ -2,7 +2,7 @@ library(ggplot2)
 library(reshape2)
 library(gridExtra)
 library(grid)
-data = read.csv(file = snakemake@input[[1]], header=T, stringsAsFactors=F, skip = 6, sep = '\t')
+data = read.csv(file = snakemake@input$rna_metrics, header=T, stringsAsFactors=F, skip = 6, sep = '\t')
 data = data[order(data$PF_ALIGNED_BASES, decreasing = T),]
 data_pct = data[,c("READ_GROUP","PCT_RIBOSOMAL_BASES","PCT_CODING_BASES","PCT_UTR_BASES","PCT_INTRONIC_BASES","PCT_INTERGENIC_BASES")]
 data = data[,c("READ_GROUP","RIBOSOMAL_BASES","CODING_BASES","UTR_BASES","INTRONIC_BASES","INTERGENIC_BASES")]


### PR DESCRIPTION
`plot_rna_metrics.R` fails due to `snakemake@input[[1]]` when used in the context of `extract_expression_species.smk`. Had to ensure input is also named in the context of `extract_expression_single.smk`