### PR TITLE
Feature/stamp stats

### DIFF
--- a/.test/config.yaml
+++ b/.test/config.yaml
@@ -45,3 +45,4 @@ MAPPING:
         outFilterMatchNmin: 0
         outFilterMatchNminOverLread: 0
         outFilterScoreMinOverLread: 0
+DEBUG: True

--- a/Snakefile
+++ b/Snakefile
@@ -88,9 +88,9 @@ rule filter:
         expand('plots/{sample}_UMI_dropped.pdf', sample=samples.index),
         'reports/filter.html',
         'plots/BC_drop.pdf'
-        
+
 rule map:
-    input:  
+    input:
         expand('data/{sample}_final.bam', sample=samples.index),
         expand('logs/{sample}_hist_out_cell.txt', sample=samples.index),
         expand('plots/{sample}_knee_plot.pdf', sample=samples.index),
@@ -104,14 +104,15 @@ rule map:
         'plots/Count_vs_gene.pdf',
         'summary/R_Seurat_objects.rdata',
         'plots/yield.pdf'
-        
+        'summary/barcode_stats_pre_filter.csv',
+        'summary/barcode_stats_post_filter.csv',
+
 rule extract:
     input:
         expand('logs/{sample}_umi_per_gene.tsv', sample=samples.index),
         expand('plots/{sample}_rna_metrics.pdf', sample=samples.index),
         'summary/umi_expression_matrix.tsv',
         'summary/counts_expression_matrix.tsv'
-        
 
 rule split_species:
     input:
@@ -129,7 +130,6 @@ rule extract_species:
         expand('summary/Experiment_{species}_counts_expression_matrix.tsv', species=config['META']['species']),
         expand('summary/Experiment_{species}_umi_expression_matrix.tsv', species=config['META']['species']),
         expand('plots/{species}/{sample}_rna_metrics.pdf', sample=samples.index, species=config['META']['species'])
-        
 
 
 include: "rules/generate_meta.smk"

--- a/Snakefile
+++ b/Snakefile
@@ -103,7 +103,7 @@ rule map:
         # 'plots/Count_vs_gene.html',
         'plots/Count_vs_gene.pdf',
         'summary/R_Seurat_objects.rdata',
-        'plots/yield.pdf'
+        'plots/yield.pdf',
         'summary/barcode_stats_pre_filter.csv',
         'summary/barcode_stats_post_filter.csv',
 

--- a/envs/plots_ext.yaml
+++ b/envs/plots_ext.yaml
@@ -6,10 +6,10 @@ dependencies:
   - r=3.4.1
   - r-ggplot2=2.2.1
   - r-gridextra
-  - r-reshape2
   - r-viridis
   - r-stringdist
   - r-dplyr=0.7.4
+  - r-rlang=0.2.1
   - r-mvtnorm
   - r-seurat
   - r-hmisc

--- a/rules/map.smk
+++ b/rules/map.smk
@@ -211,9 +211,14 @@ rule violine_plots:
 
 rule summary_stats:
 	input:
-		R_objects='summary/R_Seurat_objects.rdata'
+		R_objects='summary/R_Seurat_objects.rdata',
+		hist_cell=expand('logs/{sample}_hist_out_cell.txt', sample=samples.index),
 	conda: '../envs/plots_ext.yaml'
 	output:
-		stats='summary/stats.csv',
+		stats_pre='summary/barcode_stats_pre_filter.csv',
+		stats_post='summary/barcode_stats_post_filter.csv',
+	params:
+		sample_names=lambda wildcards: samples.index,
+		batches=lambda wildcards: samples.loc[samples.index, 'batch']
 	script:
 		'../scripts/create_summary_stats.R'

--- a/rules/map.smk
+++ b/rules/map.smk
@@ -208,3 +208,12 @@ rule violine_plots:
 		R_objects='summary/R_Seurat_objects.rdata'
 	script:
 		'../scripts/plot_violine.R'
+
+rule summary_stats:
+	input:
+		R_objects='summary/R_Seurat_objects.rdata'
+	conda: '../envs/plots_ext.yaml'
+	output:
+		stats='summary/stats.csv',
+	script:
+		'../scripts/create_summary_stats.R'

--- a/scripts/create_summary_stats.R
+++ b/scripts/create_summary_stats.R
@@ -1,0 +1,70 @@
+#' ---
+#' title:  plot_violine.R
+#' author: Sebastian Mueller (sebm_at_posteo.de)
+#' date:   2018-04-10
+#' desc: Creating varios summary statistics 
+
+# o   A delimited file containing information for each STAMP (before cut-off) on number of UMIs, number of Genes detected/captured and the number of NGS-reads
+# o   A separate delimited file containing information for each STAMP (after cut-off) on number of UMIs, number of Genes detected/captured and the number of NGS-reads
+# Example of the format could be as follows:
+# STAMP id          Number of NGS-reads       Number of UMIs       Number of Genes Detected
+# STAMP1           1000000                           50000                       6000
+#' ---
+### for debug
+# If you wish to access the snakefile object first invoke snakemake and save the session automatically
+# Since there are no debug flags to my knowledge, just uncomment the line below and run snakemake which
+# creates an R object that can be loaded into a custom R session
+
+setwd("~/workspace/code/dropSeqPipe/.test")
+load("snakemake_create_summary_stats.rdata")
+# load(file="R_image_create_summary_stats.rdata")
+
+if (snakemake@config$DEBUG) {
+ message("In debug mode: saving R objects to inspect later")
+ save(snakemake, file="snakemake_create_summary_stats.rdata")
+}
+
+####/debug
+library(dplyr) # Dataframe manipulation
+library(Matrix) # Sparse matrices
+library(stringr)
+library(RColorBrewer)
+library(devtools)
+library(Seurat)
+library(plotly)
+
+# importing Seurat object
+
+# creating environment so objects don't get overwritten upon loading
+env_imported_r_objects <- new.env()
+load(file = file.path(snakemake@input$R_objects), envir = env_imported_r_objects)
+# attach
+seuratobj <- env_imported_r_objects$seuratobj
+meta.data <- seuratobj@meta.data
+
+#median calculator
+meta.data %>%
+  group_by(orig.ident) %>%
+  summarise(median_number_genes     = median(nGene),
+            median_Counts_per_STAMP = median(nCounts),
+            median_UMIs_per_STAMP   = median(nUMI),
+            mean_UMI_per_Gene       = mean(umi.per.gene),
+            mean_Ribo_frac          = mean(pct.Ribo),
+            mean_Mito_frac          = mean(pct.mito),
+            read_length             = median(read_length), # should be all the same anyway..
+            expected_cells          = median(expected_cells), # should be all the same anyway..
+            actual_number_barcodes  = n()) %>%
+   write.csv(file.path(snakemake@output$stats)) #writes table for excel           n = n()) %>%
+# highest, lowest count/UMI Stamp
+# pre STAMP stats
+
+# hist out goes into knee plots 
+		# 'logs/{sample}_hist_out_cell.txt'
+		# """export _JAVA_OPTIONS=-Djava.io.tmpdir={params.temp_directory} && BAMTagHistogram -m {params.memory}\
+		# TAG=XC\
+# https://hpc.nih.gov/apps/dropseq.html
+# there is not hint in documentation on any filtering (only read quality), but the lowest count is >1 (stange!))
+
+if (snakemake@config$DEBUG) {
+ save.image(file="R_image_create_summary_stats.rdata")
+}


### PR DESCRIPTION
# Experimental debug mode for R-scripts in snakemake

using `DEBUG: True` flag in `config.yaml` to produce R-objects in `debug` folder which can be used for debugging.

# Producing barcode summaries to easily compare experiments/samples:

        'summary/barcode_stats_pre_filter.csv',
        'summary/barcode_stats_post_filter.csv',

Example files are attached, (csv was replaced by txt since github doesn't allow csv).

At the moment, I've included the rule into `map.smk` again, but we should probably create a new rule-file e.g. `post-processing.smk` or so?

[barcode_stats_pre_filter.txt](https://github.com/Hoohm/dropSeqPipe/files/2562783/barcode_stats_pre_filter.txt)
[barcode_stats_post_filter.txt](https://github.com/Hoohm/dropSeqPipe/files/2562785/barcode_stats_post_filter.txt)
