### PR TITLE
Resolve issue with vioplot

### DIFF
--- a/envs/r.yaml
+++ b/envs/r.yaml
@@ -12,6 +12,8 @@ dependencies:
   - r-seurat=2
   - r-hmisc
   - r-tidyverse
+  - r-rcpp
+  - r-fs
   - r-devtools
   - r-rcolorbrewer
   - font-ttf-dejavu-sans-mono=2.37

--- a/scripts/plot_violine.R
+++ b/scripts/plot_violine.R
@@ -137,7 +137,7 @@ gg <- ggplot(meta.data, aes(x = nUMI, y = nCounts, color = orig.ident)) +
 
 # dev.new()
 # htmlwidgets::saveWidget(ggplotly(gg), file.path(getwd(),snakemake@output$html_umivscounts))
-ggsave(gg, file = file.path(getwd(), snakemake@output$pdf_umivscounts), width = 12, height = 7)
+ggsave(gg, file = file.path(snakemake@output$pdf_umivscounts), width = 12, height = 7)
 
 # how about unaligned reads/UMI?
 # Note(Seb): raw.data is actually filtered data i.e. nr of genes likely to be smaller than input data!
@@ -184,7 +184,7 @@ gg <- ggplot(meta.data, aes(x = nUMI, y = nGene, color = orig.ident)) +
 
 # dev.new()
 # htmlwidgets::saveWidget(ggplotly(gg),
-# file.path(getwd(), snakemake@output$html_umi_vs_gene))
+# file.path(snakemake@output$html_umi_vs_gene))
 ggsave(gg, file = snakemake@output$pdf_umi_vs_gene, width = 12, height = 7)
 
 
@@ -201,7 +201,7 @@ gg <- ggplot(meta.data, aes(x = nCounts, y = nGene, color = orig.ident)) +
 
 # dev.new()
 # htmlwidgets::saveWidget(ggplotly(gg),
-#                       file.path(getwd(), snakemake@output$html_count_vs_gene))
+#                       file.path(snakemake@output$html_count_vs_gene))
 
 ggsave(gg, file = snakemake@output$pdf_count_vs_gene, width = 12, height = 7)
 


### PR DESCRIPTION
Resolves #83 and #84 

I encountered a similar issue. The input to the vioplot rule is an absolute path so `getwd()` is not needed.

Dependency on Rcpp added for devtools as fs required by usethis: https://github.com/r-lib/fs/issues/90#issuecomment-498500264